### PR TITLE
ci: fix release asset publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,9 @@ jobs:
 
       - uses: actions/checkout@v5
         with:
-          # FIXME: doesn't work because tag may be older than workflow actions
+          # FIXME: tag doesn't work because tag may be older than workflow actions
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ needs.release.outputs.tag }}
+          # ref: ${{ needs.release.outputs.tag }}
           lfs: true
 
       - name: Build Extension


### PR DESCRIPTION
Should fix error: Detached HEAD state cannot match any release groups